### PR TITLE
Ensure user exists in moodle when processing registration cancellation

### DIFF
--- a/classes/local/job/memberships_job.php
+++ b/classes/local/job/memberships_job.php
@@ -276,7 +276,9 @@ class memberships_job extends job {
         // Process unenrolment.
         if ($registration->get('sourcestatus') == RegistrationStatus::CANCELLED) {
             $user = $contact->get_associated_user();
-            $plugin->unenrol($enrolmentinstance, $user->to_record());
+            if ($user instanceof user_persistent) {
+                $plugin->unenrol($enrolmentinstance, $user->to_record());
+            }
             // Cleanup registration.
             $registration->delete();
         }


### PR DESCRIPTION
When a user in moodle is deleted before the sync task runs the return value into user is false. This checks the return value to ensure it is a valid user object before processing the unenrolment.

The `get_associated_user()` function returns a user_persistent object or `false` which is why this check is introduced.

This addresses Issue #120 

Another alternative is to try, catch and throw Throwable and catch in run function but this should work just as fine. 