### PR TITLE
Timezones feature

### DIFF
--- a/classes/local/job/outcomes_job.php
+++ b/classes/local/job/outcomes_job.php
@@ -135,7 +135,7 @@ class outcomes_job extends job {
         $plugin = api::get_enrolment_plugin();
         $pluginconfig = $plugin->get_plugin_config();
         $lockfactory = static::get_lock_factory();
-        $lock = $lockfactory->get_lock($this->get_lock_resource(), self::TIME_LOCK_TIMEOUT);
+        $lock = $lockfactory->get_lock($this->get_lock_resource(), 1);
         if ($lock) {
             $limit = $pluginconfig->get('outcomejobdefaultlimit');
             $registrations = registration_persistent::get_records(
@@ -174,6 +174,7 @@ class outcomes_job extends job {
                         // Update scheduling information on persistent after successfull save.
                         $jobpersistent->set('timelastrequest', time());
                         $jobpersistent->save();
+                        $lock->release();
                     }
                 }
             }

--- a/classes/local/job/outcomes_job.php
+++ b/classes/local/job/outcomes_job.php
@@ -135,7 +135,7 @@ class outcomes_job extends job {
         $plugin = api::get_enrolment_plugin();
         $pluginconfig = $plugin->get_plugin_config();
         $lockfactory = static::get_lock_factory();
-        $lock = $lockfactory->get_lock($this->get_lock_resource(), 1);
+        $lock = $lockfactory->get_lock($this->get_lock_resource(), self::TIME_LOCK_TIMEOUT);
         if ($lock) {
             $limit = $pluginconfig->get('outcomejobdefaultlimit');
             $registrations = registration_persistent::get_records(

--- a/classes/local/learner_progress.php
+++ b/classes/local/learner_progress.php
@@ -26,6 +26,8 @@ require_once($CFG->dirroot . '/grade/querylib.php');
 use coding_exception;
 use completion_completion;
 use completion_info;
+use core_date;
+use DateTime;
 use grade_item;
 use stdClass;
 
@@ -293,8 +295,11 @@ class learner_progress {
      */
     public function get_keyed_data_for_arlo() {
         $data = [];
+        $tz = core_date::get_user_timezone_object();
         if ($this->get_datelastcourseaccess()) {
-            $data['LastActivityDateTime'] = date('Y-m-d\TH:i:s.0000000+00:00', $this->get_datelastcourseaccess());
+            $lastactivitydate = new DateTime(null, $tz);
+            $lastactivitydate->setTimestamp($this->get_datelastcourseaccess());
+            $data['LastActivityDateTime'] = $lastactivitydate->format(ENROL_ARLO_DATETIME_OFFSET_FORMAT);
         }
         if ($this->get_progressstatus()) {
             $data['ProgressStatus'] = $this->get_progressstatus();
@@ -312,7 +317,9 @@ class learner_progress {
             $data['ProgressStatus'] = $this->get_progressstatus();
         }
         if ($this->get_datecompleted()) {
-            $data['CompletedDateTime'] = date('Y-m-d\TH:i:s.0000000+00:00', $this->get_datecompleted());
+            $completedatetime = new DateTime(null, $tz);
+            $completedatetime->setTimestamp($this->get_datecompleted());
+            $data['CompletedDateTime'] = $completedatetime->format(ENROL_ARLO_DATETIME_OFFSET_FORMAT);
         }
         return $data;
     }

--- a/lib.php
+++ b/lib.php
@@ -43,6 +43,14 @@ use enrol_arlo\local\job\contacts_job;
 use enrol_arlo\local\job\outcomes_job;
 
 /**
+ * DateTimeOffset format yyyy-mm-ddThh:mm:ss.fffffffzzzz.
+ *
+ * API requires 7 digits of precision for microtime however PHP supports 6 digits
+ * of precision so we pad the 7th with a zero.
+ */
+define('ENROL_ARLO_DATETIME_OFFSET_FORMAT', 'Y-m-d\TH:i:s.u0P');
+
+/**
  * Arlo enrolment plugin class.
  *
  * @package     enrol_arlo {@link https://docs.moodle.org/dev/Frankenstyle}


### PR DESCRIPTION
Add timezone support for LastActivityDateTime, CompletedDateTime fields. Use DateTime and custom format to support mimick an MS DATETIME OFFSET. Arlo requires microseconds to be at a precision of 7 or will fail. PHP only supports to 6 digits.

Use:
`define('ENROL_ARLO_DATETIME_OFFSET_FORMAT', 'Y-m-d\TH:i:s.u0P');`