### PR TITLE
Plugin now 3.10+ compatible?

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -1,0 +1,66 @@
+name: moodle-plugin-ci
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+
+    services:
+      postgres:
+        image: postgres:9.6
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.3'
+            moodle-branch: 'MOODLE_39_STABLE'
+          - php: '7.3'
+            moodle-branch: 'MOODLE_310_STABLE'
+          - php: '7.4'
+            moodle-branch: 'MOODLE_311_STABLE'
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: pgsql
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit --coverage-text
+
+      - name: Behat tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome

--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -33,7 +33,7 @@ class enrol_arlo_privacy_provider_testcase extends \core_privacy\tests\provider_
 
     protected $plugingenerator;
 
-    public function setUp() {
+    public function setUp() : void {
         global $CFG;
         require_once($CFG->dirroot . '/enrol/arlo/lib.php');
 

--- a/tests/username_generator_test.php
+++ b/tests/username_generator_test.php
@@ -33,7 +33,7 @@ class enrol_arlo_username_generator_testcase extends \core_privacy\tests\provide
     /**
      * @throws coding_exception
      */
-    public function setUp() {
+    public function setUp() : void {
         global $CFG;
 
         require_once($CFG->dirroot . '/enrol/arlo/lib.php');


### PR DESCRIPTION
Hi Tony, 
I've taken the liberty to run the plugin against Moodle 3.10 and Moodle 3.11 with the phpunit tests already present in the plugin . Would you now deem this to be 3.10+ compatible ? 

https://github.com/hitteshahuja/moodle-enrol_arlo/actions/runs/925621142

Regards,
Hittesh 