### PR TITLE
Add new email only matching method.

### DIFF
--- a/classes/form/admin/configuration.php
+++ b/classes/form/admin/configuration.php
@@ -44,6 +44,7 @@ class configuration extends \moodleform {
         $options[user_matching::MATCH_BY_USER_DETAILS] = get_string('matchbyarlouserdetails', 'enrol_arlo');
         $options[user_matching::MATCH_BY_CODE_PRIMARY] = get_string('matchbyarlocodeprimary', 'enrol_arlo');
         $options[user_matching::MATCH_BY_AUTO] = get_string('matchbyauto', 'enrol_arlo');
+        $options[user_matching::MATCH_BY_USER_EMAIL] = get_string('matchbyemail', 'enrol_arlo');
 
         $form->addElement('header', 'useraccountmatching', get_string('useraccountmatching', 'enrol_arlo'));
         $form->setExpanded('useraccountmatching', true);

--- a/classes/local/enum/user_matching.php
+++ b/classes/local/enum/user_matching.php
@@ -35,6 +35,10 @@ class user_matching {
     /** @var int MATCH_BY_AUTO match using MATCH_BY_USER_DETAILS then MATCH_BY_CODE_PRIMARY */
     const MATCH_BY_AUTO = 3;
 
+    /** @var MATCH_BY_USER_EMAIL match by email */
+    const MATCH_BY_USER_EMAIL = 4;
+
     /** @var int MATCH_BY_DEFAULT default user match method to use. */
     const MATCH_BY_DEFAULT = 2;
+
 }

--- a/classes/local/user_matcher.php
+++ b/classes/local/user_matcher.php
@@ -51,6 +51,9 @@ class user_matcher {
         if ($matchuseraccountsby == user_matching::MATCH_BY_USER_DETAILS) {
             return static::match_against_user_details($firstname, $lastname, $email);
         }
+        if ($matchuseraccountsby == user_matching::MATCH_BY_USER_EMAIL) {
+            return static::match_against_user_email($email);
+        }
         // Match by code primary.
         if ($matchuseraccountsby == user_matching::MATCH_BY_CODE_PRIMARY) {
             return static::match_against_idnumber($idnumber);
@@ -96,6 +99,29 @@ class user_matcher {
         $conditions = [
             'firstname' => $firstname,
             'lastname' => $lastname,
+            'email' => $email,
+            'deleted' => 1
+        ];
+        return $DB->get_records_select('user', $select, $conditions);
+    }
+
+    /**
+     * Match against Email information. Uses LOWER to case insensitive matching.
+     *
+     * @param $email
+     * @return array
+     * @throws \dml_exception
+     * @throws coding_exception
+     */
+    public static function match_against_user_email($email) {
+        global $DB;
+        $email      = clean_param($email, PARAM_EMAIL);
+        if (empty($email)) {
+            throw new coding_exception('Email parameter is empty after being cleaned.');
+        }
+        $select = "LOWER(email) = LOWER(:email) AND
+                   deleted <> :deleted";
+        $conditions = [
             'email' => $email,
             'deleted' => 1
         ];

--- a/lang/en/enrol_arlo.php
+++ b/lang/en/enrol_arlo.php
@@ -182,6 +182,10 @@ Arlo CodePrimary - This will attempt a match between fields Arlo Contact CodePri
 <br>
 Will try <strong>Method 1</strong> if no match will then try <strong>Method 2</strong>.
 </p>
+<strong>Method 4</strong>
+<br>
+Will attempt a match using the email address in arlo against the email address in Moodle.
+</p>
 <p>
 If no match is found using any of the Methods a Moodle user account will be created based on Arlo Contact details.
 </p>';


### PR DESCRIPTION
This adds a new user matching algorithm to allow matching on email address only - rather than the more restrictive version which requires the user firstname and lastname to match what is in arlo.