### PR TITLE
Push results based on Registration Order payment

### DIFF
--- a/classes/Arlo/AuthAPI/Resource/ContactEmployment.php
+++ b/classes/Arlo/AuthAPI/Resource/ContactEmployment.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace enrol_arlo\Arlo\AuthAPI\Resource;
+
+/**
+ * Class ContactEmployment
+ * @package enrol_arlo\Arlo\AuthAPI\Resource
+ */
+class ContactEmployment extends AbstractResource {
+    public $Organisation;
+}

--- a/classes/Arlo/AuthAPI/Resource/ContactEmployment.php
+++ b/classes/Arlo/AuthAPI/Resource/ContactEmployment.php
@@ -1,4 +1,28 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * ContactEmployment resource definition for enrol_arlo.
+ *
+ * @package     enrol_arlo
+ * @author      Donald Barrett <donaldb@skills.org.nz>
+ * @copyright   2022 onwards, Skills Consulting Group Ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @link        https://developer.arlo.co/doc/api/2012-02-01/auth/resources/contactemployment
+ */
 
 namespace enrol_arlo\Arlo\AuthAPI\Resource;
 
@@ -7,5 +31,59 @@ namespace enrol_arlo\Arlo\AuthAPI\Resource;
  * @package enrol_arlo\Arlo\AuthAPI\Resource
  */
 class ContactEmployment extends AbstractResource {
+    /**
+     * A string describing the position of this individual within the organisation, up to 64 characters long.
+     * @var string $Position
+     */
+    public $Position;
+
+    /**
+     * A string describing the department this individual is associated with in the organisation, up to 64 characters long.
+     * @var string $Department
+     */
+    public $Department;
+
+    /**
+     * A string describing the branch of the organisation that employs this individual, up to 64 characters long.
+     * @var string $Branch
+     */
+    public $Branch;
+
+    /**
+     * A string describing the business region this individual is associated with, up to 64 characters long.
+     * @var string $BusinessRegion
+     */
+    public $BusinessRegion;
+
+    /**
+     * A string describing the location of the business this individual is associated with, up to 64 characters long.
+     * @var string $BusinessLocation
+     */
+    public $BusinessLocation;
+
+    /**
+     * A string describing the area of the business this individual is associated with, up to 64 characters long.
+     * @var string $BusinessArea
+     */
+    public $BusinessArea;
+
+    /**
+     * A string describing the type of employment such as Contractor or Consultant, up to 64 characters long.
+     * @var string $EmploymentStatus
+     */
+    public $EmploymentStatus;
+
+    /**
+     * @var Contact $Contact Reference to the Contact resource representing the individual associated with this resource.
+     */
+    public $Contact;
+
+    /**
+     * Reference to the Organisation resource representing the organisation associated with this resource.
+     * @var Organisation $Organisation
+     */
     public $Organisation;
+
+    /** @var Contact $Manager Reference to a Contact resource representing the manager of this individual. */
+    public $Manager;
 }

--- a/classes/Arlo/AuthAPI/Resource/Order.php
+++ b/classes/Arlo/AuthAPI/Resource/Order.php
@@ -1,0 +1,130 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Order resource definition for enrol_arlo.
+ *
+ * @package     enrol_arlo
+ * @author      Donald Barrett <donaldb@skills.org.nz>
+ * @copyright   2022 onwards, Skills Consulting Group Ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @link        https://developer.arlo.co/doc/api/2012-02-01/auth/resources/contactemployment
+ */
+
+namespace enrol_arlo\Arlo\AuthAPI\Resource;
+
+/**
+ * Class Order
+ * @package enrol_arlo\Arlo\AuthAPI\Resource
+ */
+class Order extends AbstractResource {
+    /** @var int $OrderID An integer value that uniquely identifies this resource within the platform. */
+    public $OrderID;
+
+    /** @var string $UniqueIdentifier A GUID value that uniquely identifies this resource across any platform. */
+    public $UniqueIdentifier;
+
+    /** @var string $Code 	A string representing a code of the order. */
+    public $Code;
+
+    /** @var string $ReferenceCode 	A custom reference code (such as a purchase number), up to 256 characters. */
+    public $ReferenceCode;
+
+    /** @var string $Date The date of the order. */
+    public $Date;
+
+    /** @var string $DueDate The due date of any payments for the order. */
+    public $DueDate;
+
+    /** @var bool $LineAmountsTaxInclusive Determines whether line amounts for the order are tax inclusive. */
+    public $LineAmountsTaxInclusive;
+
+    /**
+     * The expected payment method for the order, usually set when the order was created.
+     * This should be used for informational purposes only, and may differ to the actual payment method used for the order.
+     * @var string $ExpectedPaymentMethod
+     */
+    public $ExpectedPaymentMethod;
+
+    /** @var float $SubTotal The total of the order, excluding any tax amount. */
+    public $SubTotal;
+
+    /** @var float $TotalTax The total amount of tax for all lines on the order. */
+    public $TotalTax;
+
+    /** @var float $Total The total of the order, including tax. */
+    public $Total;
+
+    /** @var string $CurrencyCode Three-letter alpha code of the currency the order has been created in. */
+    public $CurrencyCode;
+
+    /**
+     * A UTC DateTime value indicating when the order was approved. Omitted if the order has not been approved.
+     * @var string $ApprovedDateTime
+     */
+    public $ApprovedDateTime;
+
+    /**
+     * A UTC DateTime value indicating when an invoice for the order was recorded as sent. Omitted if no invoice has been sent.
+     * @var string $MarkedAsInvoiceSentDateTime
+     */
+    public $MarkedAsInvoiceSentDateTime;
+
+    /**
+     * A UTC DateTime value indicating when the order was marked as fully paid. Omitted if the order has not been fully paid.
+     * @var string $MarkedAsPaidDateTime
+     */
+    public $MarkedAsPaidDateTime;
+
+    /**
+     * A UTC DateTime value indicating when the order was cancelled. Omitted if the order has not been cancelled.
+     * @var string $CancelledDateTime
+     */
+    public $CancelledDateTime;
+
+    /**
+     * An OrderStatus value representing the current state of this order,
+     * such as awaiting approval, expired, completed or cancelled.
+     * @var string $Status
+     */
+    public $Status;
+
+    /** @var string $CreatedDateTime A UTC DateTime value indicating when this resource was created. This value is read-only. */
+    public $CreatedDateTime;
+
+    /**
+     * A UTC DateTime value indicating when this resource was last modified. This value is read-only.
+     * @var string $LastModifiedDateTime
+     */
+    public $LastModifiedDateTime;
+
+    /**
+     * Reference to a Contact resource that represents the billed individual for this order.
+     * NOTE: Orders billed to organisations will still have a billing contact.
+     * @var Contact $BillToContact
+     */
+    public $BillToContact;
+
+    /**
+     * Reference to a Organisation resource that represents the billed organisation for this order.
+     * Omitted if the order is to be billed to a private individual.
+     * @var Organisation $BillToOrganisation
+     */
+    public $BillToOrganisation;
+
+    /** @var OrderLines $Lines Reference to an OrderLines resource that contains a collection of lines related to this order. */
+    public $Lines;
+}

--- a/classes/Arlo/AuthAPI/Resource/OrderLine.php
+++ b/classes/Arlo/AuthAPI/Resource/OrderLine.php
@@ -1,0 +1,102 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * OrderLine resource definition for enrol_arlo.
+ *
+ * @package     enrol_arlo
+ * @author      Donald Barrett <donaldb@skills.org.nz>
+ * @copyright   2022 onwards, Skills Consulting Group Ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @link        https://developer.arlo.co/doc/api/2012-02-01/auth/resources/contactemployment
+ */
+
+namespace enrol_arlo\Arlo\AuthAPI\Resource;
+
+/**
+ * Class OrderLine
+ * @package enrol_arlo\Arlo\AuthAPI\Resource
+ */
+class OrderLine extends AbstractResource {
+    /**
+     * @var int $OrderLineID An integer value that uniquely identifies this resource within the platform.
+     */
+    public $OrderLineID;
+
+    /**
+     * @var int $LineNumber An integer value identifying the number of this line within the order.
+     */
+    public $LineNumber;
+
+    /**
+     * The base amount for the item, supporting up to 4 decimal places of precision.
+     * This amount may be tax inclusive or exclusive depending on the LineAmountsTaxInclusive setting on the parent order.
+     * @var float $UnitAmount
+     */
+    public $UnitAmount;
+
+    /**
+     * The quantity multiplier for the line.
+     * @var int $Quantity
+     */
+    public $Quantity;
+
+    /**
+     * The total amount of any discounts applied to the line. Omitted if the line has no associated discounts.
+     * @var float $DiscountAmount
+     */
+    public $DiscountAmount;
+
+    /**
+     * The amount of tax for the line, rounded to 2 decimal places of precision. Omitted if the line has no associated tax.
+     * @var float $TaxAmount
+     */
+    public $TaxAmount;
+
+    /**
+     * The total for the line, inclusive of any discount amount, rounded to 2 decimal places of precision.
+     * This amount may be tax inclusive or exclusive depending on the LineAmountsTaxInclusive setting on the parent order.
+     * @var float $LineAmount
+     */
+    public $LineAmount;
+
+    /**
+     * @var string $AccountCode The revenue or income account code for the line.
+     */
+    public $AccountCode;
+
+    /**
+     * @var string $TaxAccountCode The tax account code for the line. Omitted if the line has no associated tax.
+     */
+    public $TaxAccountCode;
+
+    /**
+     * Reference to the Registration resource this orderline is for.
+     * Included only if there is a registration associated with the line.
+     * @var Registration $Registration
+     */
+    public $Registration;
+
+    /**
+     * Reference to the Event this orderline is for.
+     * Included only if the line is associated with an event run privately for an organisation.
+     * @var Event $Event
+     */
+    public $Event;
+
+    /** @var Order $Order The parent Order that owns this instance. */
+    public $Order;
+}

--- a/classes/Arlo/AuthAPI/Resource/Registration.php
+++ b/classes/Arlo/AuthAPI/Resource/Registration.php
@@ -31,6 +31,11 @@ class Registration extends AbstractResource {
     public $Comments;
 
     /**
+     * @var OrderLine $OrderLine Reference to the OrderLine resource for this registration, if associated with a purchase order.
+     */
+    protected $OrderLine;
+
+    /**
      * @var Contact associated resource.
      */
     protected $Contact;
@@ -44,6 +49,24 @@ class Registration extends AbstractResource {
      * @var OnlineActivity associated resource.
      */
     protected $OnlineActivity;
+
+    /**
+     * Set the OrderLine data for this Registration.
+     *
+     * @param OrderLine $orderline The order line resource.
+     */
+    public function setOrderLine(OrderLine $orderline) {
+        $this->OrderLine = $orderline;
+    }
+
+    /**
+     * Get the OrderLine resource.
+     *
+     * @return OrderLine
+     */
+    public function getOrderLine() {
+        return $this->OrderLine;
+    }
 
     /**
      * @return mixed

--- a/classes/form/admin/configuration.php
+++ b/classes/form/admin/configuration.php
@@ -100,6 +100,10 @@ class configuration extends \moodleform {
         $form->setDefault('pusheventresults', 1);
         $form->addHelpButton('pusheventresults', 'pusheventresults', 'enrol_arlo');
 
+        $form->addElement('advcheckbox', 'pushpaidorders', get_string('pushpaidorders', 'enrol_arlo'));
+        $form->setDefault('pushpaidorders', 0);
+        $form->addHelpButton('pushpaidorders', 'pushpaidorders', 'enrol_arlo');
+
         $form->addElement('header', 'other', get_string('other'));
         $form->setExpanded('other', true);
 

--- a/classes/local/config/arlo_plugin_config.php
+++ b/classes/local/config/arlo_plugin_config.php
@@ -98,6 +98,10 @@ class arlo_plugin_config extends plugin_config {
                 'type' => PARAM_INT,
                 'default' => 1
             ],
+            'donotpushunpaidorders' => [
+                'type' => PARAM_INT,
+                'default' => 1
+            ],
             'emailsendnewaccountdetails' => [
                 'type' => PARAM_INT,
                 'default' => 1

--- a/classes/local/config/arlo_plugin_config.php
+++ b/classes/local/config/arlo_plugin_config.php
@@ -98,9 +98,9 @@ class arlo_plugin_config extends plugin_config {
                 'type' => PARAM_INT,
                 'default' => 1
             ],
-            'donotpushunpaidorders' => [
+            'pushpaidorders' => [
                 'type' => PARAM_INT,
-                'default' => 1
+                'default' => 0
             ],
             'emailsendnewaccountdetails' => [
                 'type' => PARAM_INT,

--- a/classes/local/external.php
+++ b/classes/local/external.php
@@ -23,6 +23,7 @@ use enrol_arlo\Arlo\AuthAPI\Resource\Event;
 use enrol_arlo\Arlo\AuthAPI\Resource\EventIntegrationData;
 use enrol_arlo\Arlo\AuthAPI\Resource\OnlineActivity;
 use enrol_arlo\Arlo\AuthAPI\Resource\OnlineActivityIntegrationData;
+use enrol_arlo\Arlo\AuthAPI\Resource\OrderLine;
 use enrol_arlo\local\enum\arlo_type;
 use enrol_arlo\local\persistent\event_persistent;
 use enrol_arlo\local\persistent\online_activity_persistent;
@@ -49,6 +50,30 @@ defined('MOODLE_INTERNAL') || die();
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class external {
+
+    /**
+     * Get a single order line from Arlo and deserialize to resource object.
+     *
+     * @param int $id Arlo registration source id
+     * @return OrderLine Arlo OrderLine resource.
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \moodle_exception
+     * @throws coding_exception
+     */
+    public static function get_order_line_resource(int $id) : OrderLine {
+        if ($id <= 0) {
+            throw new coding_exception('UnexpectedValueException');
+        }
+        $pluginconfig = new arlo_plugin_config();
+        $client = client::get_instance();
+        $requesturi = new RequestUri();
+        $requesturi->setHost($pluginconfig->get('platform'));
+        $requesturi->setResourcePath("registrations/$id");
+        $requesturi->addExpand('OrderLine/Order');
+        $request = new Request('GET', $requesturi->output(true));
+        $response = $client->send_request($request);
+        return response_processor::process($response);
+    }
 
     /**
      * Get a single registration from Arlo and deserialize to resource object.

--- a/classes/local/job/outcomes_job.php
+++ b/classes/local/job/outcomes_job.php
@@ -154,6 +154,15 @@ class outcomes_job extends job {
                         if (!$user) {
                             throw new moodle_exception('moodleaccountdoesnotexist');
                         }
+                        // Check payment status.
+                        try {
+                            $orderline = external::get_order_line_resource($registrationpersistent->get('sourceid'));
+                        } catch (\moodle_exception $exception) {
+                            if ($exception->getMessage() == 'error/httpstatus:404') {
+                                // No order line resource. Carry on.
+                            }
+                        }
+
                         $registrationid = $registrationpersistent->get('sourceid');
                         $sourceregistration = external::get_registration_resource($registrationid);
                         $learnerprogress = new learner_progress($course, $user);

--- a/classes/local/job/outcomes_job.php
+++ b/classes/local/job/outcomes_job.php
@@ -183,7 +183,13 @@ class outcomes_job extends job {
                     } finally {
                         $registrationpersistent->set('timelastrequest', time());
                         // Reset update flag.
-                        $registrationpersistent->set('updatesource', 0);
+                        if (isset($exception) && $exception instanceof Exception &&
+                                $exception->getMessage() == 'error/ordernotpaid') {
+                            // Ensure that this result will keep trying until it is paid.
+                            $registrationpersistent->set('updatesource', 1);
+                        } else {
+                            $registrationpersistent->set('updatesource', 0);
+                        }
                         $registrationpersistent->save();
                         // Update scheduling information on persistent after successfull save.
                         $jobpersistent->set('timelastrequest', time());

--- a/classes/local/job/outcomes_job.php
+++ b/classes/local/job/outcomes_job.php
@@ -154,7 +154,6 @@ class outcomes_job extends job {
                         if (!$user) {
                             throw new moodle_exception('moodleaccountdoesnotexist');
                         }
-
                         $registrationid = $registrationpersistent->get('sourceid');
                         $sourceregistration = external::get_registration_resource($registrationid);
                         $learnerprogress = new learner_progress($course, $user);

--- a/classes/local/job/outcomes_job.php
+++ b/classes/local/job/outcomes_job.php
@@ -163,9 +163,9 @@ class outcomes_job extends job {
                             if ($pluginconfig->get('pushpaidorders')) {
                                 try {
                                     // Check payment status.
-                                    $orderline = external::get_order_line_resource($registrationpersistent->get('sourceid'));
-                                    if (empty($orderline->Order->MarkedAsPaidDateTime)) {
-                                        throw new \moodle_exception('error/ordernotpaid');
+                                    $order = external::get_order_resource($registrationpersistent->get('sourceid'));
+                                    if (empty($order->MarkedAsPaidDateTime)) {
+                                        throw new \moodle_exception('ordernotpaid');
                                     }
                                 } catch (\moodle_exception $exception) {
                                     if ($exception->getMessage() !== 'error/httpstatus:404') {

--- a/classes/local/job/outcomes_job.php
+++ b/classes/local/job/outcomes_job.php
@@ -161,7 +161,7 @@ class outcomes_job extends job {
                         $data = $learnerprogress->get_keyed_data_for_arlo();
                         if (!empty($data)) {
                             $this->trace->output(implode(',', $data));
-                            if ($pluginconfig->get('donotpushunpaidorders')) {
+                            if ($pluginconfig->get('pushpaidorders')) {
                                 try {
                                     // Check payment status.
                                     $orderline = external::get_order_line_resource($registrationpersistent->get('sourceid'));

--- a/lang/en/enrol_arlo.php
+++ b/lang/en/enrol_arlo.php
@@ -233,6 +233,11 @@ $string['pushonlineactivityresults'] = 'Push Online Activity results';
 $string['pushonlineactivityresults_help'] = 'Push result information from enrolment instances mapped to <strong>OnlineActivities</strong> back to Arlo';
 $string['pusheventresults'] = 'Push Event results';
 $string['pusheventresults_help'] = 'Push result information from enrolment instances mapped to <strong>Events</strong> back to Arlo';
+$string['pushpaidorders'] = 'Push results for paid Orders (if an Order exists)';
+$string['pushpaidorders_help'] = '
+Push result information from an enrolment instance that has a <strong>Registration</strong> with an <strong>Order</strong> that has been paid for back to Arlo. 
+<br><br>
+Results for any <strong>Registration</strong> that does not have an <strong>Order</strong> are pushed back to Arlo.';
 $string['pluginname'] = 'Arlo enrolment';
 $string['pluginname_desc'] = '<p>These enrolments are managed by local_arlo</p>';
 $string['pluginstatus'] = 'Status';


### PR DESCRIPTION
This allows results pushing from Moodle to Arlo based on Order payment status. If the user has an Order that hasn't been marked as paid for in Arlo, the results aren't pushed back to Arlo. 

Any user that doesn't have an Order in Arlo are processed as usual.

These additions will allow companies to control the updation of a contacts grade to a registration in Arlo based on the contacts Order payment status if the registration has an associated Order

This also has the implementation for a Contact organisation. 

The use of the arlo payment status is also part of another moodle availability condition based on order payment status [moodle-availability_arlo](https://github.com/ShiftNZ/moodle-availability_arlo) which needs some updations